### PR TITLE
Should be using the size of a `cuchar` not an `int` for colors

### DIFF
--- a/src/zengine/zgl.nim
+++ b/src/zengine/zgl.nim
@@ -371,7 +371,7 @@ proc loadDefaultBuffers() =
 
   glGenBuffers(1, addr lines.vboId[1]);
   glBindBuffer(GL_ARRAY_BUFFER, lines.vboId[1]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(int)*4*2*MAX_LINES_BATCH, addr lines.colors[0], GL_DYNAMIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(cuchar)*4*2*MAX_LINES_BATCH, addr lines.colors[0], GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(currentShader.colorLoc);
   glVertexAttribPointer(currentShader.colorLoc, 4, cGL_UNSIGNED_BYTE, GL_TRUE, 0, nil);
 
@@ -388,7 +388,7 @@ proc loadDefaultBuffers() =
 
   glGenBuffers(1, addr triangles.vboId[1]);
   glBindBuffer(GL_ARRAY_BUFFER, triangles.vboId[1]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(int)*4*3*MAX_TRIANGLES_BATCH, addr triangles.colors[0], GL_DYNAMIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(cuchar)*4*3*MAX_TRIANGLES_BATCH, addr triangles.colors[0], GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(currentShader.colorLoc);
   glVertexAttribPointer(currentShader.colorLoc, 4, cGL_UNSIGNED_BYTE, GL_TRUE, 0, nil);
 
@@ -411,7 +411,7 @@ proc loadDefaultBuffers() =
 
   glGenBuffers(1, addr quads.vboId[2]);
   glBindBuffer(GL_ARRAY_BUFFER, quads.vboId[2]);
-  glBufferData(GL_ARRAY_BUFFER, sizeof(int)*4*4*MAX_QUADS_BATCH, addr quads.colors[0], GL_DYNAMIC_DRAW);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(cuchar)*4*4*MAX_QUADS_BATCH, addr quads.colors[0], GL_DYNAMIC_DRAW);
   glEnableVertexAttribArray(currentShader.colorLoc);
   glVertexAttribPointer(currentShader.colorLoc, 4, cGL_UNSIGNED_BYTE, GL_TRUE, 0, nil);
 


### PR DESCRIPTION
Personally, I think this should be a `GLubyte`, but let's keep these datatypes consistent for now.