### PR TITLE
Free the mouse

### DIFF
--- a/src/zengine/core.nim
+++ b/src/zengine/core.nim
@@ -37,7 +37,7 @@ proc init*(width, height: int, mainWindowTitle: string) =
   doAssert 0 == glSetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1)
   doAssert 0 == glSetAttribute(SDL_GL_MULTISAMPLESAMPLES, 4)
 
-  window = createWindow(mainWindowTitle, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width.cint, height.cint, SDL_WINDOW_SHOWN or SDL_WINDOW_OPENGL or SDL_WINDOW_INPUT_GRABBED)
+  window = createWindow(mainWindowTitle, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width.cint, height.cint, SDL_WINDOW_SHOWN or SDL_WINDOW_OPENGL)
 
   if window.isNil:
     quit(QUIT_FAILURE)


### PR DESCRIPTION
Fixes #9.

Doesn't conflict with any of the existing examples.  `00` still will hide the mouse and keep it captured in the window, but for `01` and `02`, I can now move the mouse outside of the client screen.