### PR TITLE
Add `strfmt` as a dependency

### DIFF
--- a/zengine.nimble
+++ b/zengine.nimble
@@ -11,6 +11,7 @@ srcDir        = "src"
 # Dependencies
 
 requires "nim >= 0.17.1"
+requires "strfmt >= 0.8.4"
 requires "sdl2 >= 1.1"
 requires "opengl >= 1.1.0"
 requires "glm >= 0.1.1"


### PR DESCRIPTION
It's pure Nim IIRC and pretty damn useful.  I wish it was part of the standard library.

Can we include this?
Please?
Please?
Please?Please?
Please??
PLEASE???
PLEEEEAASSEE?!?!