### PR TITLE
Fix texture transparency issue

### DIFF
--- a/src/zengine/zgl.nim
+++ b/src/zengine/zgl.nim
@@ -441,23 +441,10 @@ proc zglLoadTexture*(data: pointer, width, height: int, pixelFormat: uint32, mip
 
   glBindTexture(GL_TEXTURE_2D, id)
 
-  case sdl2.SDL_BYTESPERPIXEL(pixelFormat)
-  of 4:
-    case pixelFormat
-    of sdl2.SDL_PIXELFORMAT_RGBA8888:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8.ord, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
-    of sdl2.SDL_PIXELFORMAT_ABGR8888:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB.ord, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
-    else:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA.ord, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
+  if sdl2.SDL_BYTESPERPIXEL(pixelFormat) == 4:
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8.ord, width, height, 0, GL_RGBA, GL_UNSIGNED_BYTE, data)
   else:
-    case pixelFormat
-    of sdl2.SDL_PIXELFORMAT_RGB888:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8.ord, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data)
-    of sdl2.SDL_PIXELFORMAT_RGB24:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8.ord, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data)
-    else:
-      glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB.ord, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data)
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB8.ord, width, height, 0, GL_RGB, GL_UNSIGNED_BYTE, data)
 
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)


### PR DESCRIPTION
I discovered that when a PNG is loaded, it was triggering the case at line no. 450, which wasn't making an RGBA texture in OpenGL.

I also included some minor changes so we are hard-specifying the bit depth of each channel.  I'd also thing it would be a good idea to only use one type of texture (only make RGBA textures) but that's for another later discussion.

Also, the case states for lines 446-452 and 454-460 are kind of moot now, since they all resolve to the same proc call I collapsed it into an if statement.

Closes #36