### PR TITLE
Add ZObject & Entity3D datatype

### DIFF
--- a/src/zengine/entity3d.nim
+++ b/src/zengine/entity3d.nim
@@ -1,0 +1,29 @@
+# Entity3D is a ZObject child type that is used to represent an object in 3D
+# space
+from zobject import ZObject, getNextID
+import glm
+import strfmt
+
+
+type Entity3D* = ref object of ZObject
+  origin*: Vec3f        # Origin point of the object
+  pos*: Vec3f           # Location of the object
+  orientation*: Mat3f   # Orientation of the object
+
+
+# Creates an new Entity3D object.  postion and origin are set to 0.  The orientation
+# matrix is set to the identity matrix.
+proc newEntity3D*(): Entity3D=
+  result = Entity3D(
+    id: getNextID(),
+    origin: vec3f(0),
+    pos: vec3f(0),
+    orientation: mat3f(1)
+  )
+
+
+method `$`*(self: Entity3D): string=
+  var s = "Entity3D [{0}]".fmt(self.id)
+  s &= "\n  pos={0}".fmt($self.pos)
+  return s
+

--- a/src/zengine/zobject.nim
+++ b/src/zengine/zobject.nim
@@ -2,16 +2,18 @@
 
 # Next available ID
 var nextID:uint = 1
+proc getNextID*(): uint=
+  result = nextID
+  nextID.inc()
 
 
 type ZObject* = ref object of RootObj
-  id: uint    # Unique Id for the ZObject, positive integer
+  id*: uint   # Unique Id for the ZObject, positive integer
 
 
 # Instatiate a new ZObject
 proc newZObject*(): ZObject=
-  result = ZObject(id: nextID)
-  nextID.inc()
+  result = ZObject(id: getNextID())
 
 
 # Get the ID of the ZObject.  It will always be a positive integer

--- a/src/zengine/zobject.nim
+++ b/src/zengine/zobject.nim
@@ -1,0 +1,24 @@
+# ZObject is a base type for many objects in Zengine
+
+# Next available ID
+var nextID:uint = 1
+
+
+type ZObject* = ref object of RootObj
+  id: uint    # Unique Id for the ZObject, positive integer
+
+
+# Instatiate a new ZObject
+proc newZObject*(): ZObject=
+  result = ZObject(id: nextID)
+  nextID.inc()
+
+
+# Get the ID of the ZObject.  It will always be a positive integer
+proc id*(self: ZObject): uint=
+  return self.id
+
+
+method `$`*(self: ZObject): string=
+  return "ZObject [" & $self.id & "]"
+


### PR DESCRIPTION
We're going to need something like this for #23 .  I wouldn't consider the `Entity3D` object complete, but it's a good starting point.

If you've also noticed a lot of other game engines/frameworks have some sort of base object.  It's not necessary right now, but it can be handy down the road.  Right now I have it do nothing more than store an ID.