### PR TITLE
Add `debugDraw()` proc for Entity3D

### DIFF
--- a/examples/src/zengine_examples/08_Entity3D/main.nim
+++ b/examples/src/zengine_examples/08_Entity3D/main.nim
@@ -1,0 +1,118 @@
+# Debug drawing for an Entity3D
+
+import zengine, sdl2, opengl, glm
+
+
+# Constants
+const
+  ScreenWidth = 960
+  ScreenHeight = 540
+
+
+# Init zengine
+zengine.init(ScreenWidth, ScreenHeight, "DebugDraw for Entity3D test")
+zengine.gui.init()
+
+
+# State variables
+var
+  # Window control
+  evt = sdl2.defaultEvent
+  running = true
+
+  # Camera control
+  camera = Camera(
+    position: vec3f(0, 1, 2),
+    target: vec3f(0, 1, 0),
+    up: vec3f(0, 1, 0),
+    fovY: 60
+  )
+  mouseXRel: int
+  mouseYRel: int
+
+  obj = newEntity3D()
+
+# Set the location
+obj.position.y += 1
+obj.orientation = quatf(vec3f(0, 0, 1), 0)
+obj.origin = vec3f(0.2, -0.2, -0.2)
+
+
+# Use a first person camera
+camera.setMode(CameraMode.FirstPerson)
+
+var clock = Timer()
+clock.start()
+
+# Main Game loop
+while running:
+  # Reset
+  mouseXRel = 0
+  mouseYRel = 0
+  clock.tick()
+
+  # Check for new input
+  pollInput()
+
+  # Poll for events
+  while sdl2.pollEvent(evt):
+    case evt.kind:
+      # Shutdown if X button clicked
+      of QuitEvent:
+        running = false
+
+      of KeyDown:
+        let keyEvent = cast[KeyboardEventPtr](addr evt)
+        if keyEvent.keysym.sym == K_W:
+          obj.position.z += 1.0 * clock.deltaTime()
+        elif keyEvent.keysym.sym == K_S:
+          obj.position.z -= 1.0 * clock.deltaTime()
+        elif keyEvent.keysym.sym == K_A:
+          obj.position.x -= 1.0 * clock.deltaTime()
+        elif keyEvent.keysym.sym == K_D:
+          obj.position.x += 1.0 * clock.deltaTime()
+        elif keyEvent.keysym.sym == K_R:
+          obj.position.y += 1.0 * clock.deltaTime()
+        elif keyEvent.keysym.sym == K_F:
+          obj.position.y -= 1.0 * clock.deltaTime()
+
+      of KeyUp:
+        let keyEvent = cast[KeyboardEventPtr](addr evt)
+        # Shutdown if ESC pressed
+        if keyEvent.keysym.sym == K_ESCAPE:
+          running = false
+
+        # Get some info about the camera state
+        if keyEvent.keysym.sym == K_C:
+          echo("camera.position=" & $camera.position)
+          echo("camera.target=" & $camera.target)
+          echo("camera.up=" & $camera.up)
+
+      # Update camera if mouse moved
+      of MouseMotion:
+        let mouseMoveEvent = cast[MouseMotionEventPtr](addr evt)
+        mouseXRel = mouseMoveEvent.xrel
+        mouseYRel = mouseMoveEvent.yrel
+
+      else:
+        discard
+
+  # Swivel the orientation
+  obj.orientation *= quatf(vec3f(1, 0, 0), mouseYRel.float / 100f)
+  obj.orientation *= quatf(vec3f(0, 1, 0), mouseXRel.float / 100f)
+
+  # Start drawing
+  beginDrawing()
+  clearBackground(BLACK)
+
+  begin3dMode(camera)
+  drawPlane(vec3f(0, 0, 0), vec2f(32, 32), GRAY)
+  debugDraw(obj)
+  end3dMode()
+
+  # done with drawing, display the screen
+  endDrawing()
+  swapBuffers()
+
+# Shutdown
+zengine.core.shutdown()

--- a/src/zengine.nim
+++ b/src/zengine.nim
@@ -1,9 +1,10 @@
-import zengine/[camera, core, color, geom, gui, models, primitives, text, texture, timer, zgl]
+import zengine/[camera, core, color, entity3d, geom, gui, models, primitives, text, texture, timer, zgl]
 
 export 
   zengine.camera,
   zengine.core,
   zengine.color,
+  zengine.entity3d,
   zengine.geom,
   zengine.gui,
   zengine.models,

--- a/src/zengine/entity3d.nim
+++ b/src/zengine/entity3d.nim
@@ -1,14 +1,17 @@
 # Entity3D is a ZObject child type that is used to represent an object in 3D
 # space
-from zobject import ZObject, getNextID
 import glm
 import strfmt
+from zobject import ZObject, getNextID
+from color import WHITE, RED, GREEN, BLUE
+from models import drawSphereWires, drawCube
+from zgl import zglPushMatrix, zglPopMatrix, zglTranslatef, zglRotatef
 
 
 type Entity3D* = ref object of ZObject
   origin*: Vec3f        # Origin point of the object
-  pos*: Vec3f           # Location of the object
-  orientation*: Mat3f   # Orientation of the object
+  position*: Vec3f      # Location of the object
+  orientation*: Quatf   # Orientation of the object
 
 
 # Creates an new Entity3D object.  postion and origin are set to 0.  The orientation
@@ -17,13 +20,52 @@ proc newEntity3D*(): Entity3D=
   result = Entity3D(
     id: getNextID(),
     origin: vec3f(0),
-    pos: vec3f(0),
-    orientation: mat3f(1)
+    position: vec3f(0),
+    orientation: quatf()
   )
 
 
 method `$`*(self: Entity3D): string=
   var s = "Entity3D [{0}]".fmt(self.id)
-  s &= "\n  pos={0}".fmt($self.pos)
+  s &= "\n  position={0}".fmt($self.position)
   return s
+
+
+# Does a debug drawing of the `Entity3D` object's parameters
+proc debugDraw*(self: Entity3D; levelOfDetail: int=10)=
+  let
+    zero = vec3f(0)
+    noRot = (0.0, 1.0, 0.0, 0.0)  # Used for no rotation
+
+  # Move to where we need to draw
+  zglPushMatrix()
+  zglTranslatef(self.position)
+
+  # Draw the position and the origin points
+  drawSphereWires(zero, 0.15, levelOfDetail, levelOfDetail, WHITE)
+  drawSphereWires(self.origin, 0.1, levelOfDetail, levelOfDetail, RED)
+
+  # X+
+  zglPushMatrix()
+  zglRotatef(self.orientation)
+  zglTranslatef(0.5, 0, 0)
+  drawCube(zero, noRot, 0.9, 0.1, 0.1, RED)
+  zglPopMatrix()
+
+  # Y+
+  zglPushMatrix()
+  zglRotatef(self.orientation)
+  zglTranslatef(0, 0.5, 0)
+  drawCube(zero, noRot, 0.1, 0.9, 0.1, GREEN)
+  zglPopMatrix()
+
+  # Z+
+  zglPushMatrix()
+  zglRotatef(self.orientation)
+  zglTranslatef(0, 0, 0.5)
+  drawCube(zero, noRot, 0.1, 0.1, 0.9, BLUE)
+  zglPopMatrix()
+
+  # Cleanup
+  zglPopMatrix()
 

--- a/src/zengine/zgl.nim
+++ b/src/zengine/zgl.nim
@@ -862,6 +862,11 @@ proc zglTranslatef*(x, y, z: float) =
   var tmp = translate(mat4f(), vec3f(x, y, z))
   currentMatrix[] = currentMatrix[] * tmp
 
+
+proc zglTranslatef*(v: Vec3f) {.inline.}=
+  currentMatrix[] *= mat4f().translate(v)
+
+
 proc zglRotatef*(angleDeg: float, x, y, z: float) =
   # var matRotation = matrixIdentity()
 
@@ -872,6 +877,14 @@ proc zglRotatef*(angleDeg: float, x, y, z: float) =
   # currentMatrix[] = matrixMultiply(currentMatrix[], matRotation)
   var matRotation = rotate(mat4f(), vec3f(x, y, z), degToRad(angleDeg))
   currentMatrix[] = currentMatrix[] * matRotation
+
+
+proc zglRotatef*(angleDeg: float; v: Vec3f) {.inline.} =
+  zglRotatef(angleDeg, v.x, v.y, v.z)
+
+
+proc zglRotatef*(quat: Quatf) {.inline.} =
+  currentMatrix[] = currentMatrix[].rotate(quat.axis(), quat.angle())
 
 proc zglScalef*(x, y, z: float) =
   var tmp = scale(mat4f(), vec3f(x, y, z))


### PR DESCRIPTION
This helps visual parts of an Entity3D, and where it's pointing.

Added an example (08) to display what's going on.

Closes #41